### PR TITLE
Update Annotation Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-grid-layout": "^1.5.2",
+        "react-markdown": "^8.0.6",
         "react-router-dom": "^7.6.3",
         "react-syntax-highlighter": "^15.6.1"
       },
@@ -1312,6 +1313,15 @@
         "@types/deep-eql": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "dev": true,
@@ -1339,6 +1349,21 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/parse-json": {
@@ -1865,6 +1890,16 @@
         "npm": ">=6"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
@@ -2173,6 +2208,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/decode-named-character-reference/node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "dev": true,
@@ -2195,10 +2253,18 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -2523,6 +2589,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -2829,6 +2901,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
+      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hastscript": {
       "version": "6.0.0",
       "license": "MIT",
@@ -2950,6 +3032,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
+      "license": "MIT"
+    },
     "node_modules/is-alphabetical": {
       "version": "1.0.4",
       "license": "MIT",
@@ -2973,6 +3061,29 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -3028,6 +3139,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3141,6 +3264,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "dev": true,
@@ -3240,6 +3372,78 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-definitions": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
+      "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
+      "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-definitions": "^5.0.0",
+        "micromark-util-sanitize-uri": "^1.1.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-generated": "^2.0.0",
+        "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "dev": true,
@@ -3247,6 +3451,448 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -3294,6 +3940,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -3665,6 +4320,73 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-markdown": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.6.tgz",
+      "integrity": "sha512-KgPWsYgHuftdx510wwIzpwf+5js/iHqBR+fzxefv8Khk3mFbnioF1bmL2idHN3ler0LMQmICKeDrWnZrX9mtbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/prop-types": "^15.0.0",
+        "@types/unist": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "prop-types": "^15.0.0",
+        "property-information": "^6.0.0",
+        "react-is": "^18.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-rehype": "^10.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-object": "^0.4.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/react-markdown/node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react-markdown/node_modules/property-information": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
+      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react-markdown/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-markdown/node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "dev": true,
@@ -3779,6 +4501,37 @@
         "node": ">=6"
       }
     },
+    "node_modules/remark-parse": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+      "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-hast": "^12.1.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -3891,6 +4644,18 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safer-buffer": {
@@ -4019,6 +4784,15 @@
       "version": "9.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/style-to-object": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
+      }
     },
     "node_modules/stylis": {
       "version": "4.2.0",
@@ -4172,6 +4946,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "dev": true,
@@ -4227,6 +5021,103 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-generated": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
+      "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "dev": true,
@@ -4271,6 +5162,54 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-grid-layout": "^1.5.2",
+    "react-markdown": "^8.0.6",
     "react-router-dom": "^7.6.3",
     "react-syntax-highlighter": "^15.6.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,10 +69,12 @@ const AppWithQuery = () => {
     rootSpanId: string,
     note: string,
     rating: Rating | null
-  ): Promise<void> => {
+  ): Promise<{ isNew: boolean }> => {
+    let res: any = null;
+    const isNew = annotationId === "";
+    
     try {
-      let res: any = null;
-      if (annotationId === "") {
+      if (isNew) {
         if (rating) {
           res = await createAnnotation(rootSpanId, note || "", rating);
         }
@@ -95,12 +97,15 @@ const AppWithQuery = () => {
 
       if (res) {
         console.log(
-          annotationId ? "Annotation updated:" : "Annotation created:",
+          isNew ? "Annotation created:" : "Annotation updated:",
           res
         );
       }
+      
+      return { isNew };
     } catch (err) {
       console.error("Failed to save annotation", err);
+      throw err; // Re-throw the error so the Annotation component can handle it
     }
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ const AppWithQuery = () => {
   // Use TanStack Query instead of manual state management
   // Always call the hook - handle null context inside the hook
   const { data: annotatedRootSpans = [], isLoading, error } = useRootSpansContext(currentContext);
-  const { updateRootSpanInCache, invalidateAll, invalidateBatch, invalidateProject } = useRootSpanMutations();
+  const { updateRootSpanInCache, invalidateBatch, invalidateProject } = useRootSpanMutations();
   
   // Add the queryClient hook
   const queryClient = useQueryClient();
@@ -162,21 +162,7 @@ const AppWithQuery = () => {
     }
   };
 
-  const handleSpansOnDeleteBatch = async (batchId: string) => {
-    try {
-      // Update spans to remove batch association
-      annotatedRootSpans.forEach(span => {
-        if (span.batchId === batchId) {
-          updateRootSpanInCache(span.id, s => ({ ...s, batchId: null }));
-        }
-      });
-
-      // Invalidate queries
-      invalidateAll();
-    } catch (error) {
-      console.error("Failed to delete batch", error);
-    }
-  };
+  // handleSpansOnDeleteBatch function removed - database handles cleanup automatically
 
   const AppContent = () => {
     const { isDarkMode } = useTheme();
@@ -191,7 +177,7 @@ const AppWithQuery = () => {
             <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/projects" element={<Projects />} />
-          <Route path="/projects/:projectId" element={<Batches onDeleteBatch={handleSpansOnDeleteBatch} />} />
+          <Route path="/projects/:projectId" element={<Batches />} />
           <Route
             path="/projects/:projectId/batches/:batchId"
             element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -222,10 +222,9 @@ const AppWithQuery = () => {
 
           <Route path="/projects/:projectId/batches/:batchId/rootSpans/:rootSpanId" element={<RootSpanDetails />} />
           <Route
-            path="/projects/:projectId/batches/:batchId/annotation" // TODO: change to annotation/:rootSpanId
+            path="/projects/:projectId/batches/:batchId/annotation/:rootSpanId"
             element={
               <Annotation
-                annotatedRootSpans={annotatedRootSpans}
                 onSave={handleSaveAnnotation}
               />
             }

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -33,6 +33,7 @@ const Annotation = ({ onSave}: Props) => {
   const [displayFormattedInput, setDisplayFormattedInput] = useState(false);
   const [displayFormattedOutput, setDisplayFormattedOutput] = useState(false);
   const [displayConfirmCategorize, setDisplayConfirmCategorize] = useState(false);
+  const [isFooterHidden, setIsFooterHidden] = useState(false);
 
   // Track original values to detect changes
   const [originalAnnotation, setOriginalAnnotation] = useState<{
@@ -283,6 +284,29 @@ const Annotation = ({ onSave}: Props) => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [currentSpanIndex, annotatedRootSpans, navigate, projectId, batchId, projectName, batchName, setRating, autoSave, goToPreviousSpan, goToNextSpan]);
 
+  // Monitor footer visibility from localStorage
+  useEffect(() => {
+    const checkFooterVisibility = () => {
+      const savedFooterState = localStorage.getItem('llmonade-footer-hidden');
+      const footerHidden = savedFooterState ? JSON.parse(savedFooterState) : false;
+      setIsFooterHidden(footerHidden);
+    };
+
+    // Check initially
+    checkFooterVisibility();
+
+    // Listen for storage changes (in case footer is toggled in another tab/component)
+    window.addEventListener('storage', checkFooterVisibility);
+    
+    // Also listen for custom events from the footer component
+    window.addEventListener('footerVisibilityChanged', checkFooterVisibility);
+
+    return () => {
+      window.removeEventListener('storage', checkFooterVisibility);
+      window.removeEventListener('footerVisibilityChanged', checkFooterVisibility);
+    };
+  }, []);
+
     const displayPrevOrDoneButton = () => {
       if (currentSpanIndex === annotatedRootSpans.length - 1) {
         return (
@@ -391,7 +415,7 @@ const Annotation = ({ onSave}: Props) => {
             `
           },
           gap: 3,
-          height: 'calc(100vh - 200px)',
+          height: isFooterHidden ? 'calc(100vh - 120px)' : 'calc(100vh - 200px)',
           minHeight: '600px'
         }}
       >
@@ -736,7 +760,10 @@ const Annotation = ({ onSave}: Props) => {
             p: 2, 
             backgroundColor: theme.palette.mode === 'dark' ? '#2a2a2a' : '#e8f5e8',
             borderBottom: '1px solid',
-            borderBottomColor: 'divider'
+            borderBottomColor: 'divider',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center'
           }}>
             <Typography variant="h6" sx={{ fontWeight: 'bold', color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121' }}>
               Input
@@ -747,7 +774,7 @@ const Annotation = ({ onSave}: Props) => {
                 size="small"
                 sx={{
                   px: 3,
-                  minWidth: 100,
+                  minWidth: 50,
                   borderColor: 'secondary.main',
                   color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
                   fontWeight: 600,
@@ -766,7 +793,7 @@ const Annotation = ({ onSave}: Props) => {
                 disabled={!currentSpan.formatted_output}
                 sx={{
                   px: 3,
-                  minWidth: 100,
+                  minWidth: 75,
                   borderColor: 'secondary.main',
                   color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
                   fontWeight: 600,

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { Container, Typography, Box, Button, TextField, Chip, Paper, useTheme as muiUseTheme, LinearProgress } from "@mui/material";
+import { Container, Typography, Box, Button, TextField, Chip, Paper, useTheme as muiUseTheme } from "@mui/material";
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import type { AnnotatedRootSpan, Rating as RatingType } from "../types/types";
+import type { Rating as RatingType } from "../types/types";
 import { useRootSpansByBatch } from "../hooks/useRootSpans";
 import { getPhoenixDashboardUrl } from "../services/services";
 
@@ -270,86 +270,92 @@ const Annotation = ({ onSave}: Props) => {
 
                     {/* Center Section - Progress */}
           <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', minWidth: '400px' }}>
-            {annotatedRootSpans.length > 0 && (
-              <>
-                <Typography variant="h6" sx={{ fontWeight: 'bold', color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121', mb: 1 }}>
-                  Grading Progress
-                </Typography>
-                
-                {/* Enhanced Progress Bar Container */}
-                <Box sx={{ 
-                  position: 'relative', 
-                  width: '100%', 
-                  height: 40,
-                  borderRadius: 20,
-                  backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.08)',
-                  border: '2px solid',
-                  borderColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.12)',
-                  overflow: 'hidden',
-                  boxShadow: 'inset 0 2px 4px rgba(0,0,0,0.1)'
-                }}>
-                  {/* Progress Fill */}
-                  <Box
-                    sx={{
-                      position: 'absolute',
-                      left: 0,
-                      top: 0,
-                      height: '100%',
-                      width: `${((currentSpanIndex + 1) / annotatedRootSpans.length) * 100}%`,
-                      background: `linear-gradient(135deg, 
-                        ${theme.palette.secondary.main} 0%, 
-                        ${theme.palette.secondary.light} 50%, 
-                        ${theme.palette.secondary.main} 100%)`,
-                      borderRadius: 'inherit',
-                      transition: 'width 0.3s ease-in-out',
-                      boxShadow: '0 2px 8px rgba(255, 235, 59, 0.3)'
-                    }}
-                  />
+            {annotatedRootSpans.length > 0 && (() => {
+              // Calculate how many spans have been annotated (have a rating)
+              const annotatedCount = annotatedRootSpans.filter(span => span.annotation?.rating).length;
+              const progressPercentage = (annotatedCount / annotatedRootSpans.length) * 100;
+              
+              return (
+                <>
+                  <Typography variant="h6" sx={{ fontWeight: 'bold', color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121', mb: 1 }}>
+                    Grading Progress
+                  </Typography>
                   
-                  {/* Percentage Text Overlay */}
-                  <Box
-                    sx={{
-                      position: 'absolute',
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      bottom: 0,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      zIndex: 1
-                    }}
-                  >
-                    <Typography
-                      variant="body1"
+                  {/* Enhanced Progress Bar Container */}
+                  <Box sx={{ 
+                    position: 'relative', 
+                    width: '100%', 
+                    height: 40,
+                    borderRadius: 20,
+                    backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.08)',
+                    border: '2px solid',
+                    borderColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.12)',
+                    overflow: 'hidden',
+                    boxShadow: 'inset 0 2px 4px rgba(0,0,0,0.1)'
+                  }}>
+                    {/* Progress Fill */}
+                    <Box
                       sx={{
-                        fontWeight: 'bold',
-                        fontSize: '1rem',
-                        color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
-                        textShadow: theme.palette.mode === 'dark' 
-                          ? '0 1px 2px rgba(0,0,0,0.8)' 
-                          : '0 1px 2px rgba(255,255,255,0.8)',
-                        letterSpacing: '0.5px'
+                        position: 'absolute',
+                        left: 0,
+                        top: 0,
+                        height: '100%',
+                        width: `${progressPercentage}%`,
+                        background: `linear-gradient(135deg, 
+                          ${theme.palette.secondary.main} 0%, 
+                          ${theme.palette.secondary.light} 50%, 
+                          ${theme.palette.secondary.main} 100%)`,
+                        borderRadius: 'inherit',
+                        transition: 'width 0.3s ease-in-out',
+                        boxShadow: '0 2px 8px rgba(255, 235, 59, 0.3)'
+                      }}
+                    />
+                    
+                    {/* Percentage Text Overlay */}
+                    <Box
+                      sx={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        zIndex: 1
                       }}
                     >
-                      {Math.round(((currentSpanIndex + 1) / annotatedRootSpans.length) * 100)}%
-                    </Typography>
+                      <Typography
+                        variant="body1"
+                        sx={{
+                          fontWeight: 'bold',
+                          fontSize: '1rem',
+                          color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
+                          textShadow: theme.palette.mode === 'dark' 
+                            ? '0 1px 2px rgba(0,0,0,0.8)' 
+                            : '0 1px 2px rgba(255,255,255,0.8)',
+                          letterSpacing: '0.5px'
+                        }}
+                      >
+                        {Math.round(progressPercentage)}%
+                      </Typography>
+                    </Box>
                   </Box>
-                </Box>
-                
-                <Typography 
-                  variant="body2" 
-                  sx={{ 
-                    color: 'text.secondary',
-                    mt: 1,
-                    fontSize: '0.875rem',
-                    fontWeight: 'medium'
-                  }}
-                >
-                  {currentSpanIndex + 1} of {annotatedRootSpans.length} spans
-                </Typography>
-              </>
-            )}
+                  
+                  <Typography 
+                    variant="body2" 
+                    sx={{ 
+                      color: 'text.secondary',
+                      mt: 1,
+                      fontSize: '0.875rem',
+                      fontWeight: 'medium'
+                    }}
+                  >
+                    {annotatedCount} of {annotatedRootSpans.length} spans annotated
+                  </Typography>
+                </>
+              );
+            })()}
           </Box>
 
           {/* Right Section - Navigation */}

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { Container, Typography, Box, Button, TextField, Chip, Paper, useTheme as muiUseTheme } from "@mui/material";
+import { Container, Typography, Box, Button, TextField, Chip, Paper, useTheme as muiUseTheme, Tooltip } from "@mui/material";
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
@@ -23,6 +23,32 @@ const Annotation = ({ onSave}: Props) => {
   const [rating, setRating] = useState<RatingType | null>(null);
   const location = useLocation();
   const { projectName, batchName } = location.state || {};
+
+  // Helper function to render keyboard keys
+  const renderKey = (key: string) => (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-block',
+        px: 0.75,
+        py: 0.25,
+        mx: 0.5,
+        backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.08)',
+        border: '1px solid',
+        borderColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.12)',
+        borderRadius: '4px',
+        fontFamily: 'monospace',
+        fontSize: '0.75rem',
+        fontWeight: 'bold',
+        color: theme.palette.mode === 'dark' ? '#fff' : '#333',
+        boxShadow: theme.palette.mode === 'dark' 
+          ? '0 1px 0 rgba(255, 255, 255, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.05)'
+          : '0 1px 0 rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.8)'
+      }}
+    >
+      {key}
+    </Box>
+  );
 
 
   const {data: annotatedRootSpans = [], isLoading: isLoadingSpans} = useRootSpansByBatch(batchId || null);
@@ -360,52 +386,60 @@ const Annotation = ({ onSave}: Props) => {
 
           {/* Right Section - Navigation */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, justifyContent: 'flex-end' }}>
-            <Button
-              variant="outlined"
-              onClick={goToPreviousSpan}
-              disabled={currentSpanIndex === 0}
-              size="small"
-              sx={{ 
-                px: 3, 
-                minWidth: 165,
-                borderColor: 'secondary.main',
-                color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
-                fontWeight: 600,
-                '&:hover': {
-                  borderColor: 'secondary.dark',
-                  backgroundColor: 'rgba(255, 235, 59, 0.1)',
-                },
-                '&.Mui-disabled': {
-                  borderColor: 'text.disabled',
-                  color: 'text.disabled',
-                }
-              }}
-            >
-              Previous
-            </Button>
-            <Button
-              variant="outlined"
-              onClick={goToNextSpan}
-              disabled={currentSpanIndex === annotatedRootSpans.length - 1}
-              size="small"
-              sx={{ 
-                px: 3, 
-                minWidth: 165,
-                borderColor: 'secondary.main',
-                color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
-                fontWeight: 600,
-                '&:hover': {
-                  borderColor: 'secondary.dark',
-                  backgroundColor: 'rgba(255, 235, 59, 0.1)',
-                },
-                '&.Mui-disabled': {
-                  borderColor: 'text.disabled',
-                  color: 'text.disabled',
-                }
-              }}
-            >
-              Next
-            </Button>
+            <Tooltip title={<>Previous span {renderKey('A')}</>} arrow>
+              <span>
+                <Button
+                  variant="outlined"  
+                  onClick={goToPreviousSpan}
+                  disabled={currentSpanIndex === 0}
+                  size="small"
+                  sx={{ 
+                    px: 3, 
+                    minWidth: 165,
+                    borderColor: 'secondary.main',
+                    color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                    fontWeight: 600,
+                    '&:hover': {
+                      borderColor: 'secondary.dark',
+                      backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                    },
+                    '&.Mui-disabled': {
+                      borderColor: 'text.disabled',
+                      color: 'text.disabled',
+                    }
+                  }}
+                >
+                  Previous
+                </Button>
+              </span>
+            </Tooltip>
+            <Tooltip title={<>Next span {renderKey('D')}</>} arrow>
+              <span>
+                <Button
+                  variant="outlined"
+                  onClick={goToNextSpan}
+                  disabled={currentSpanIndex === annotatedRootSpans.length - 1}
+                  size="small"
+                  sx={{ 
+                    px: 3, 
+                    minWidth: 165,
+                    borderColor: 'secondary.main',
+                    color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                    fontWeight: 600,
+                    '&:hover': {
+                      borderColor: 'secondary.dark',
+                      backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                    },
+                    '&.Mui-disabled': {
+                      borderColor: 'text.disabled',
+                      color: 'text.disabled',
+                    }
+                  }}
+                >
+                  Next
+                </Button>
+              </span>
+            </Tooltip>
           </Box>
         </Box>
 
@@ -616,33 +650,6 @@ const Annotation = ({ onSave}: Props) => {
           }}
         >          
           <Box sx={{ p: 2, flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
-            {/* Rate Response */}
-            <Box>
-              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                Rate Response
-              </Typography>
-              <Box sx={{ display: 'flex', gap: 2 }}>
-                <Button
-                  variant={rating === 'good' ? 'contained' : 'outlined'}
-                  color="success"
-                  startIcon={<ThumbUpIcon />}
-                  onClick={() => setRating('good')}
-                  size="small"
-                >
-                  Good
-                </Button>
-                <Button
-                  variant={rating === 'bad' ? 'contained' : 'outlined'}
-                  color="error"
-                  startIcon={<ThumbDownIcon />}
-                  onClick={() => setRating('bad')}
-                  size="small"
-                >
-                  Bad
-                </Button>
-              </Box>
-            </Box>
-
             {/* Notes */}
             <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
               <Typography variant="subtitle2" color="text.secondary" gutterBottom>
@@ -650,7 +657,7 @@ const Annotation = ({ onSave}: Props) => {
               </Typography>
               <TextField
                 multiline
-                rows={15}
+                rows={8}
                 fullWidth
                 variant="outlined"
                 value={note}
@@ -663,6 +670,49 @@ const Annotation = ({ onSave}: Props) => {
                   }
                 }}
               />
+            </Box>
+
+            {/* Rate Response */}
+            <Box>
+              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                Rate Response
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 2 }}>
+                <Tooltip title={<>Good {renderKey('S')}</>} arrow>
+                  <Button
+                    variant={rating === 'good' ? 'contained' : 'outlined'}
+                    color="success"
+                    startIcon={<ThumbUpIcon />}
+                    onClick={() => setRating('good')}
+                    size="medium"
+                    sx={{
+                      flex: 1,
+                      py: 0.5,
+                      fontSize: '1rem',
+                      fontWeight: 600
+                    }}
+                  >
+                    Good
+                  </Button>
+                </Tooltip>
+                <Tooltip title={<>Bad {renderKey('W')}</>} arrow>
+                  <Button
+                    variant={rating === 'bad' ? 'contained' : 'outlined'}
+                    color="error"
+                    startIcon={<ThumbDownIcon />}
+                    onClick={() => setRating('bad')}
+                    size="medium"
+                    sx={{
+                      flex: 1,
+                      py: 0.5,
+                      fontSize: '1rem',
+                      fontWeight: 600
+                    }}
+                  >
+                    Bad
+                  </Button>
+                </Tooltip>
+              </Box>
             </Box>
 
             {/* Save Button */}

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -30,7 +30,8 @@ const Annotation = ({ onSave}: Props) => {
     severity: 'success' as 'success' | 'error' | 'warning' | 'info'
   });
   const [hotkeyModalOpen, setHotkeyModalOpen] = useState(false);
-  const [displayFormattedSpan, setDisplayFormattedSpan] = useState(false);
+  const [displayFormattedInput, setDisplayFormattedInput] = useState(false);
+  const [displayFormattedOutput, setDisplayFormattedOutput] = useState(false);
   const [displayConfirmCategorize, setDisplayConfirmCategorize] = useState(false);
 
   // Track original values to detect changes
@@ -740,6 +741,45 @@ const Annotation = ({ onSave}: Props) => {
             <Typography variant="h6" sx={{ fontWeight: 'bold', color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121' }}>
               Input
             </Typography>
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Button 
+                variant="outlined" 
+                size="small"
+                sx={{
+                  px: 3,
+                  minWidth: 100,
+                  borderColor: 'secondary.main',
+                  color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                  fontWeight: 600,
+                  '&:hover': {
+                    borderColor: 'secondary.dark',
+                    backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                  }
+                }}
+                onClick={() => setDisplayFormattedInput(false)}
+              >
+                Raw
+              </Button>
+              <Button 
+                variant="outlined" 
+                size="small"
+                disabled={!currentSpan.formatted_output}
+                sx={{
+                  px: 3,
+                  minWidth: 100,
+                  borderColor: 'secondary.main',
+                  color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                  fontWeight: 600,
+                  '&:hover': {
+                    borderColor: 'secondary.dark',
+                    backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                  }
+                }}
+                onClick={() => setDisplayFormattedInput(true)}
+              >
+                Formatted
+              </Button>
+            </Box>
           </Box>
           <Box sx={{ 
             p: 2, 
@@ -754,7 +794,7 @@ const Annotation = ({ onSave}: Props) => {
               fontSize: '0.9rem',
               lineHeight: 1.5
             }}>
-              {currentSpan.input}
+              {displayFormattedInput ? <ReactMarkdown>{currentSpan.formatted_input || ''}</ReactMarkdown> : currentSpan.input}
             </pre>
           </Box>
         </Paper>
@@ -796,7 +836,7 @@ const Annotation = ({ onSave}: Props) => {
                     backgroundColor: 'rgba(255, 235, 59, 0.1)',
                   }
                 }}
-                onClick={() => setDisplayFormattedSpan(false)}
+                onClick={() => setDisplayFormattedOutput(false)}
               >
                 Raw
               </Button>
@@ -815,7 +855,7 @@ const Annotation = ({ onSave}: Props) => {
                     backgroundColor: 'rgba(255, 235, 59, 0.1)',
                   }
                 }}
-                onClick={() => setDisplayFormattedSpan(true)}
+                onClick={() => setDisplayFormattedOutput(true)}
               >
                 Formatted
               </Button>
@@ -827,7 +867,7 @@ const Annotation = ({ onSave}: Props) => {
             overflow: 'auto',
             backgroundColor: theme.palette.background.paper
           }}>
-            {displayFormattedSpan ? (
+            {displayFormattedOutput ? (
               <ReactMarkdown>{currentSpan.formatted_output || ''}</ReactMarkdown>
             ) : (
               <pre style={{ 

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -353,56 +353,58 @@ const Annotation = ({ onSave}: Props) => {
             {/* Project Box */}
             {projectName && (
             <>
-              <Box 
-              onClick={async () => {
-                const success = await autoSave();
-                if (success) {
-                  navigate(`/projects/${projectId}`, { 
-                    state: { projectName, batchName } 
-                  });
-                }
-              }}
-              sx={{
-                px: 2,
-                py: 0.75,
-                backgroundColor: theme.palette.mode === 'dark' 
-                  ? 'rgba(0, 0, 0, 0.4)' 
-                  : 'rgba(255, 255, 255, 0.9)',
-                borderRadius: 2,
-                border: '2px solid',
-                borderColor: 'secondary.main',
-                boxShadow: theme.palette.mode === 'dark'
-                  ? '0 2px 8px rgba(255, 235, 59, 0.2)'
-                  : '0 2px 8px rgba(255, 235, 59, 0.3)',
-                cursor: 'pointer',
-                '&:hover': {
-                  borderColor: 'secondary.dark',
-                  backgroundColor: 'rgba(255, 235, 59, 0.1)',
-                },
-              }}>
-                <Typography 
-                  variant="body2" 
-                  sx={{ 
-                    color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
-                    fontWeight: 'medium',
-                    fontSize: '0.875rem',
-                    letterSpacing: '0.5px'
-                  }}
-                >
-                  PROJECT
-                </Typography>
-                <Typography 
-                  variant="h6" 
-                  sx={{ 
-                    color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
-                    fontWeight: 'bold',
-                    fontSize: '1rem',
-                    mt: -0.5
-                  }}
-                >
-                  {projectName}
-                </Typography>
-              </Box>
+              <Tooltip title={<>Back to project {renderKey('Esc')}</>} arrow>
+                <Box 
+                onClick={async () => {
+                  const success = await autoSave();
+                  if (success) {
+                    navigate(`/projects/${projectId}`, { 
+                      state: { projectName, batchName } 
+                    });
+                  }
+                }}
+                sx={{
+                  px: 2,
+                  py: 0.75,
+                  backgroundColor: theme.palette.mode === 'dark' 
+                    ? 'rgba(0, 0, 0, 0.4)' 
+                    : 'rgba(255, 255, 255, 0.9)',
+                  borderRadius: 2,
+                  border: '2px solid',
+                  borderColor: 'secondary.main',
+                  boxShadow: theme.palette.mode === 'dark'
+                    ? '0 2px 8px rgba(255, 235, 59, 0.2)'
+                    : '0 2px 8px rgba(255, 235, 59, 0.3)',
+                  cursor: 'pointer',
+                  '&:hover': {
+                    borderColor: 'secondary.dark',
+                    backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                  },
+                }}>
+                  <Typography 
+                    variant="body2" 
+                    sx={{ 
+                      color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
+                      fontWeight: 'medium',
+                      fontSize: '0.875rem',
+                      letterSpacing: '0.5px'
+                    }}
+                  >
+                    PROJECT
+                  </Typography>
+                  <Typography 
+                    variant="h6" 
+                    sx={{ 
+                      color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
+                      fontWeight: 'bold',
+                      fontSize: '1rem',
+                      mt: -0.5
+                    }}
+                  >
+                    {projectName}
+                  </Typography>
+                </Box>
+              </Tooltip>
               <ChevronRightIcon sx={{ color: 'text.secondary', fontSize: '1.5rem' }} />
             </>
           )}
@@ -410,7 +412,7 @@ const Annotation = ({ onSave}: Props) => {
           {/* Batch Box */}
           {batchName && (
             <>
-              <Tooltip title={<>Back to batch {renderKey('Esc')} (auto-saves changes)</>} arrow>
+              <Tooltip title={<>Back to batch {renderKey('Esc')}</>} arrow>
                 <Box 
                 onClick={async () => {
                   const success = await autoSave();

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -231,7 +231,6 @@ const Annotation = ({ onSave}: Props) => {
         event.preventDefault();
         const success = await autoSave();
         if (success) {
-          // If we're on the last span, trigger auto-categorization like the "Done!" button
           const isLastSpan = currentSpanIndex === annotatedRootSpans.length - 1;
           navigate(`/projects/${projectId}/batches/${batchId}`, { 
             state: { 
@@ -252,18 +251,9 @@ const Annotation = ({ onSave}: Props) => {
             await goToPreviousSpan();
             break;
           case 'ArrowRight':
-            // If on last span, trigger Done functionality, otherwise Next
+            // If on last span, show confirmation dialog like the button does
             if (currentSpanIndex === annotatedRootSpans.length - 1) {
-              const success = await autoSave();
-              if (success) {
-                navigate(`/projects/${projectId}/batches/${batchId}`, { 
-                  state: { 
-                    projectName, 
-                    batchName,
-                    startCategorization: true
-                  } 
-                });
-              }
+              setDisplayConfirmCategorize(true);
             } else {
               await goToNextSpan();
             }
@@ -283,6 +273,8 @@ const Annotation = ({ onSave}: Props) => {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [currentSpanIndex, annotatedRootSpans, navigate, projectId, batchId, projectName, batchName, setRating, autoSave, goToPreviousSpan, goToNextSpan]);
+
+
 
   // Monitor footer visibility from localStorage
   useEffect(() => {

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -1,8 +1,12 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { Container, Typography, Box, Button, TextField, Chip } from "@mui/material";
+import { Container, Typography, Box, Button, TextField, Chip, Paper, useTheme as muiUseTheme } from "@mui/material";
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CancelIcon from '@mui/icons-material/Cancel';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import type { AnnotatedRootSpan, Rating as RatingType } from "../types/types";
 
 interface Props {
@@ -13,6 +17,7 @@ interface Props {
 const Annotation = ({ annotatedRootSpans, onSave}: Props) => {
   const { projectId, batchId } = useParams<{ projectId: string, batchId: string }>();
   const navigate = useNavigate();
+  const theme = muiUseTheme();
   const [note, setNote] = useState("");
   const [rating, setRating] = useState<RatingType | null>(null);
   
@@ -73,146 +78,498 @@ const Annotation = ({ annotatedRootSpans, onSave}: Props) => {
     }
   };
 
+  const getRatingIcon = (rating: string) => {
+    switch (rating) {
+      case 'good':
+        return <CheckCircleIcon sx={{ color: 'success.main', fontSize: '1.5rem' }} />;
+      case 'bad':
+        return <CancelIcon sx={{ color: 'error.main', fontSize: '1.5rem' }} />;
+      default:
+        return <CheckCircleOutlineIcon sx={{ color: 'text.disabled', fontSize: '1.5rem' }} />;
+    }
+  };
+
+  const getRatingLabel = (rating: string) => {
+    switch (rating) {
+      case 'good':
+        return 'Good';
+      case 'bad':
+        return 'Bad';
+      default:
+        return 'Not Rated';
+    }
+  };
+
   if (!currentSpan) {
-    return <div>No spans available</div>;
+    return (
+      <Container maxWidth="xl">
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
+          <Typography variant="h5" color="text.secondary">No spans available</Typography>
+        </Box>
+      </Container>
+    );
   }
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
-      {/* Header + all three columns */}
-      <Box>
-        {/* Header - Title and back button */}
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-          <Typography variant="h3" component="h1" gutterBottom>
-            Annotation Queue
-          </Typography>
-          <Button variant="contained" onClick={() => navigate(`/projects/${projectId}/batches/${batchId}`, {
-            state: { projectName, batchName }
-          })}>
-            Back to Batch
-          </Button>
+    <Container maxWidth="xl" sx={{ py: 2 }}>
+      {/* CSS Grid Layout */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            md: '1fr 1fr',
+            lg: '1fr 2fr 1fr'
+          },
+          gridTemplateRows: {
+            xs: 'auto auto auto auto auto',
+            md: 'auto auto auto 2fr auto',
+            lg: 'auto auto 1fr 1fr'
+          },
+          gridTemplateAreas: {
+            xs: `
+              "header"
+              "controls"
+              "input"
+              "output"
+              "annotation"
+            `,
+            md: `
+              "header header"
+              "controls controls"
+              "input input"
+              "output output"
+              "annotation annotation"
+            `,
+            lg: `
+              "header header header"
+              "controls output annotation"
+              "input output annotation"
+              "input output annotation"
+            `
+          },
+          gap: 3,
+          height: 'calc(100vh - 200px)',
+          minHeight: '600px'
+        }}
+      >
+        {/* Header Section */}
+        <Box
+          sx={{
+            gridArea: 'header',
+            display: 'grid',
+            gridTemplateColumns: '1fr auto 1fr',
+            alignItems: 'center',
+            gap: 2,
+            py: 1
+          }}
+        >
+          {/* Left Section - Breadcrumbs */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, justifyContent: 'flex-start' }}>
+            {/* Project Box */}
+            {projectName && (
+            <>
+              <Box 
+              onClick={() => navigate(`/projects/${projectId}`, { 
+                state: { projectName, batchName } 
+              })}
+              sx={{
+                px: 2,
+                py: 0.75,
+                backgroundColor: theme.palette.mode === 'dark' 
+                  ? 'rgba(0, 0, 0, 0.4)' 
+                  : 'rgba(255, 255, 255, 0.9)',
+                borderRadius: 2,
+                border: '2px solid',
+                borderColor: 'secondary.main',
+                boxShadow: theme.palette.mode === 'dark'
+                  ? '0 2px 8px rgba(255, 235, 59, 0.2)'
+                  : '0 2px 8px rgba(255, 235, 59, 0.3)',
+                cursor: 'pointer',
+                '&:hover': {
+                  borderColor: 'secondary.dark',
+                  backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                },
+              }}>
+                <Typography 
+                  variant="body2" 
+                  sx={{ 
+                    color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
+                    fontWeight: 'medium',
+                    fontSize: '0.875rem',
+                    letterSpacing: '0.5px'
+                  }}
+                >
+                  PROJECT
+                </Typography>
+                <Typography 
+                  variant="h6" 
+                  sx={{ 
+                    color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
+                    fontWeight: 'bold',
+                    fontSize: '1rem',
+                    mt: -0.5
+                  }}
+                >
+                  {projectName}
+                </Typography>
+              </Box>
+              <ChevronRightIcon sx={{ color: 'text.secondary', fontSize: '1.5rem' }} />
+            </>
+          )}
+
+          {/* Batch Box */}
+          {batchName && (
+            <>
+              <Box 
+              onClick={() => navigate(`/projects/${projectId}/batches/${batchId}`, { 
+                state: { projectName, batchName } 
+              })}
+              sx={{
+                px: 2,
+                py: 0.75,
+                backgroundColor: theme.palette.mode === 'dark' 
+                  ? 'rgba(0, 0, 0, 0.4)' 
+                  : 'rgba(255, 255, 255, 0.9)',
+                borderRadius: 2,
+                border: '2px solid',
+                borderColor: 'secondary.main',
+                boxShadow: theme.palette.mode === 'dark'
+                  ? '0 2px 8px rgba(33, 150, 243, 0.2)'
+                  : '0 2px 8px rgba(33, 150, 243, 0.3)',
+                cursor: 'pointer',
+                '&:hover': {
+                  borderColor: 'secondary.dark',
+                  backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                },
+              }}>
+                <Typography 
+                  variant="body2" 
+                  sx={{ 
+                    color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
+                    fontWeight: 'medium',
+                    fontSize: '0.875rem',
+                    letterSpacing: '0.5px'
+                  }}
+                >
+                  BATCH
+                </Typography>
+                <Typography 
+                  variant="h6" 
+                  sx={{ 
+                    color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
+                    fontWeight: 'bold',
+                    fontSize: '1rem',
+                    mt: -0.5
+                  }}
+                >
+                  {batchName}
+                </Typography>
+              </Box>
+            </>
+          )}
+          </Box>
+
+          {/* Center Section - Title */}
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Typography 
+              variant="h3" 
+              component="h1" 
+              sx={{ 
+                fontWeight: 'bold',
+                color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121',
+                textAlign: 'center'
+              }}
+            >
+              Annotation Queue
+            </Typography>
+            {annotatedRootSpans.length > 0 && (
+              <Typography 
+                variant="body2" 
+                sx={{ 
+                  color: 'text.secondary',
+                  mt: 0.5,
+                  fontSize: '0.875rem'
+                }}
+              >
+                {currentIndex + 1} of {annotatedRootSpans.length}
+              </Typography>
+            )}
+          </Box>
+
+          {/* Right Section - Navigation */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, justifyContent: 'flex-end' }}>
+            <Button
+              variant="outlined"
+              onClick={handlePrevious}
+              disabled={currentIndex === 0}
+              size="small"
+              sx={{ 
+                px: 3, 
+                minWidth: 165,
+                borderColor: 'secondary.main',
+                color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                fontWeight: 600,
+                '&:hover': {
+                  borderColor: 'secondary.dark',
+                  backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                },
+                '&.Mui-disabled': {
+                  borderColor: 'text.disabled',
+                  color: 'text.disabled',
+                }
+              }}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={handleNext}
+              disabled={currentIndex === annotatedRootSpans.length - 1}
+              size="small"
+              sx={{ 
+                px: 3, 
+                minWidth: 165,
+                borderColor: 'secondary.main',
+                color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                fontWeight: 600,
+                '&:hover': {
+                  borderColor: 'secondary.dark',
+                  backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                },
+                '&.Mui-disabled': {
+                  borderColor: 'text.disabled',
+                  color: 'text.disabled',
+                }
+              }}
+            >
+              Next
+            </Button>
+          </Box>
         </Box>
 
-        {/* All three columns - Input | Output | Annotate */}
-        <Box sx={{ display: 'flex', gap: 2 }}>
-          {/* Input */}
-          <Box
-            sx={{
-              width: '30%',
-              borderRadius: 2,
-              border: '2px solid',
-              borderColor: 'primary.light',
-              height: '70vh',
-              p: 2,
-              overflow: 'auto',
-            }}
-          >
-            <Typography variant="h4" component="h2" gutterBottom>
+        {/* Controls Section */}
+        <Paper
+          elevation={2}
+          sx={{
+            gridArea: 'controls',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden'
+          }}
+        >
+          <Box sx={{ 
+            p: 2, 
+            flex: 1, 
+            overflow: 'auto',
+            backgroundColor: theme.palette.background.paper,
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+            gap: 2
+          }}>
+          <Box>
+            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+              Span ID
+            </Typography>
+            <Typography variant="body1" sx={{ fontWeight: 'medium' }}>
+              {currentSpan.id || 'N/A'}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+              Span Name
+            </Typography>
+            <Typography variant="body1" sx={{ fontWeight: 'medium' }}>
+              {currentSpan.spanName || 'N/A'}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+              Current Rating
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              {getRatingIcon(currentSpan.annotation?.rating || '')}
+              <Typography variant="body1" sx={{ fontWeight: 'medium' }}>
+                {getRatingLabel(currentSpan.annotation?.rating || '')}
+              </Typography>
+            </Box>
+          </Box>
+          <Box>
+            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+              Categories
+            </Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              {currentSpan.annotation?.categories && currentSpan.annotation.categories.length > 0 ? (
+                currentSpan.annotation.categories.map(category => (
+                  <Chip key={category} label={category} size="small" variant="outlined" />
+                ))
+              ) : (
+                <Typography variant="body2" color="text.secondary">None</Typography>
+              )}
+            </Box>
+          </Box>
+          </Box>
+        </Paper>
+
+        {/* Input Section */}
+        <Paper
+          elevation={2}
+          sx={{
+            gridArea: 'input',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden'
+          }}
+        >
+          <Box sx={{ 
+            p: 2, 
+            backgroundColor: theme.palette.mode === 'dark' ? '#2a2a2a' : '#e8f5e8',
+            borderBottom: '1px solid',
+            borderBottomColor: 'divider'
+          }}>
+            <Typography variant="h6" sx={{ fontWeight: 'bold', color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121' }}>
               Input
             </Typography>
-            <pre style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{currentSpan.input}</pre>
           </Box>
+          <Box sx={{ 
+            p: 2, 
+            flex: 1, 
+            overflow: 'auto',
+            backgroundColor: theme.palette.background.paper
+          }}>
+            <pre style={{ 
+              whiteSpace: 'pre-wrap', 
+              margin: 0, 
+              fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+              fontSize: '0.9rem',
+              lineHeight: 1.5
+            }}>
+              {currentSpan.input}
+            </pre>
+          </Box>
+        </Paper>
 
-          {/* Output */}
-          <Box
-            sx={{
-              width: '40%',
-              borderRadius: 2,
-              border: '2px solid',
-              borderColor: 'primary.light',
-              height: '70vh',
-              p: 2,
-              overflow: 'auto',
-            }}
-          >
-            <Typography variant="h4" component="h2" gutterBottom>
+        {/* Output Section */}
+        <Paper
+          elevation={2}
+          sx={{
+            gridArea: 'output',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden'
+          }}
+        >
+          <Box sx={{ 
+            p: 2, 
+            backgroundColor: theme.palette.mode === 'dark' ? '#2a2a2a' : '#fff3e0',
+            borderBottom: '1px solid',
+            borderBottomColor: 'divider'
+          }}>
+            <Typography variant="h6" sx={{ fontWeight: 'bold', color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#212121' }}>
               Output
             </Typography>
-            <pre style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{currentSpan.output}</pre>
           </Box>
+          <Box sx={{ 
+            p: 2, 
+            flex: 1, 
+            overflow: 'auto',
+            backgroundColor: theme.palette.background.paper
+          }}>
+            <pre style={{ 
+              whiteSpace: 'pre-wrap', 
+              margin: 0,
+              fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+              fontSize: '0.9rem',
+              lineHeight: 1.5
+            }}>
+              {currentSpan.output}
+            </pre>
+          </Box>
+        </Paper>
 
-          {/* Annotation + Rate Responses + Notes + Save + Navigation */}
-          <Box>
-            <Typography variant="h4" component="h2" gutterBottom>
-              Annotation
-            </Typography>
-
-            <Box sx={{ textAlign: 'left', mb: 2 }}>
-              <Typography variant="h5" component="h3" gutterBottom>Categories</Typography>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                {currentSpan.annotation?.categories && currentSpan.annotation.categories.length > 0 ? (
-                  currentSpan.annotation.categories.map(category => (
-                    <Chip key={category} label={category} variant="outlined" />
-                  ))
-                ) : (
-                  <Typography variant="body2" color="text.secondary">None</Typography>
-                )}
-              </Box>
-            </Box>
-
-            {/* Rate Responses */}
-            <Box sx={{ textAlign: 'left', mb: 2 }}>
-              <Typography variant="h5" component="h3" gutterBottom>Rate Response</Typography>
-              <Box sx={{ display: 'flex', justifyContent: 'left', gap: 2 }}>
+        {/* Annotation Section */}
+        <Paper
+          elevation={2}
+          sx={{
+            gridArea: 'annotation',
+            display: 'flex',
+            flexDirection: 'column',
+            backgroundColor: theme.palette.mode === 'dark' ? '#1a1a1a' : '#f5f5f5'
+          }}
+        >          
+          <Box sx={{ p: 2, flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {/* Rate Response */}
+            <Box>
+              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                Rate Response
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 2 }}>
                 <Button
                   variant={rating === 'good' ? 'contained' : 'outlined'}
                   color="success"
                   startIcon={<ThumbUpIcon />}
                   onClick={() => setRating('good')}
-                >Good</Button>
+                  size="small"
+                >
+                  Good
+                </Button>
                 <Button
                   variant={rating === 'bad' ? 'contained' : 'outlined'}
                   color="error"
                   startIcon={<ThumbDownIcon />}
                   onClick={() => setRating('bad')}
-                >Bad</Button>
+                  size="small"
+                >
+                  Bad
+                </Button>
               </Box>
             </Box>
 
             {/* Notes */}
-            <Typography variant="h5" component="h3" gutterBottom>Notes</Typography>
-            <TextField
-              multiline
-              rows={12}
-              fullWidth
-              variant="outlined"
-              value={note}
-              onChange={(e) => setNote(e.target.value)}
-              placeholder={rating === 'bad' ? 'Note required for bad rating.' : ''}
-            />
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                Notes
+              </Typography>
+              <TextField
+                multiline
+                rows={8}
+                fullWidth
+                variant="outlined"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                placeholder={rating === 'bad' ? 'Note required for bad rating.' : 'Add your notes here...'}
+                sx={{ 
+                  flex: 1,
+                  '& .MuiOutlinedInput-root': {
+                    backgroundColor: theme.palette.background.paper,
+                  }
+                }}
+              />
+            </Box>
 
-            {/* Save */}
+            {/* Save Button */}
             <Button
               variant="contained"
               onClick={handleSave}
-              sx={{ mt: 2, alignSelf: 'flex-end' }}
               disabled={isSaveDisabled || !rating}
+              size="large"
+              sx={{ 
+                backgroundColor: 'secondary.main',
+                color: 'black',
+                fontWeight: 600,
+                '&:hover': {
+                  backgroundColor: 'secondary.dark',
+                },
+                '&.Mui-disabled': {
+                  backgroundColor: 'text.disabled',
+                  color: 'rgba(0, 0, 0, 0.26)',
+                }
+              }}
             >
               Save Annotation
             </Button>
-
-            {/* Navigation */}
-            <Box sx={{ display: 'flex', justifyContent: 'left', alignItems: 'center', gap: 2, mt: 2 }}>
-              <Button
-                variant="outlined"
-                onClick={handlePrevious}
-                disabled={currentIndex === 0}
-              >
-                Previous
-              </Button>
-              <Typography>
-                {currentIndex + 1} of {annotatedRootSpans.length}
-              </Typography>
-              <Button
-                variant="outlined"
-                onClick={handleNext}
-                disabled={currentIndex === annotatedRootSpans.length - 1}
-              >
-                Next
-              </Button>
-            </Box>
           </Box>
-        </Box>
+        </Paper>
       </Box>
     </Container>
   );

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { Container, Typography, Box, Button, TextField, Chip, Paper, useTheme as muiUseTheme, Tooltip, Snackbar, Alert } from "@mui/material";
+import { Container, Typography, Box, Button, TextField, Chip, Paper, useTheme as muiUseTheme, Tooltip, Snackbar, Alert, Dialog, DialogTitle, DialogContent, DialogActions } from "@mui/material";
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import KeyboardIcon from '@mui/icons-material/Keyboard';
 import type { Rating as RatingType } from "../types/types";
 import { useRootSpansByBatch } from "../hooks/useRootSpans";
 import { getPhoenixDashboardUrl } from "../services/services";
@@ -30,6 +31,7 @@ const Annotation = ({ onSave}: Props) => {
     message: '',
     severity: 'success' as 'success' | 'error' | 'warning' | 'info'
   });
+  const [hotkeyModalOpen, setHotkeyModalOpen] = useState(false);
 
   // Track original values to detect changes
   const [originalAnnotation, setOriginalAnnotation] = useState<{
@@ -341,13 +343,13 @@ const Annotation = ({ onSave}: Props) => {
             gridArea: 'header',
             display: 'grid',
             gridTemplateColumns: '1fr auto 1fr',
-            alignItems: 'center',
+            alignItems: 'start',
             gap: 2,
             py: 1
           }}
         >
           {/* Left Section - Breadcrumbs */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, justifyContent: 'flex-start' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, justifyContent: 'flex-start', alignSelf: 'center' }}>
             {/* Project Box */}
             {projectName && (
             <>
@@ -465,7 +467,7 @@ const Annotation = ({ onSave}: Props) => {
           </Box>
 
                     {/* Center Section - Progress */}
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', minWidth: '400px' }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', minWidth: '400px', alignSelf: 'center' }}>
             {annotatedRootSpans.length > 0 && (() => {
               // Calculate how many spans have been annotated (have a rating)
               const annotatedCount = annotatedRootSpans.filter(span => span.annotation?.rating).length;
@@ -554,9 +556,28 @@ const Annotation = ({ onSave}: Props) => {
             })()}
           </Box>
 
-          {/* Right Section - Empty for now */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, justifyContent: 'flex-end' }}>
-            {/* Navigation moved to annotation section */}
+          {/* Right Section - Hotkey Info */}
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, justifyContent: 'flex-end' }}>
+            <Tooltip title="View keyboard shortcuts" arrow>
+              <Button
+                variant="outlined"
+                startIcon={<KeyboardIcon />}
+                onClick={() => setHotkeyModalOpen(true)}
+                size="small"
+                sx={{ 
+                  px: 2,
+                  borderColor: 'secondary.main',
+                  color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                  fontWeight: 600,
+                  '&:hover': {
+                    borderColor: 'secondary.dark',
+                    backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                  }
+                }}
+              >
+                Shortcuts
+              </Button>
+            </Tooltip>
           </Box>
         </Box>
 
@@ -957,6 +978,119 @@ const Annotation = ({ onSave}: Props) => {
           </Box>
         </Paper>
       </Box>
+
+      {/* Hotkey Info Modal */}
+      <Dialog
+        open={hotkeyModalOpen}
+        onClose={() => setHotkeyModalOpen(false)}
+        aria-labelledby="hotkey-dialog-title"
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle 
+          id="hotkey-dialog-title"
+          sx={{ 
+            color: 'primary.main',
+            fontWeight: 'bold',
+            pb: 1,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            alignSelf: 'center'
+          }}
+        >
+          <KeyboardIcon />
+          Keyboard Shortcuts & Auto-Save
+        </DialogTitle>
+        <DialogContent sx={{ pb: 1 }}>
+          {/* Navigation Shortcuts */}
+          <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2, color: 'text.primary', textAlign: 'center' }}>
+            Navigation
+          </Typography>
+          <Box sx={{ mb: 3, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1, width: '280px' }}>
+              <Typography variant="body2">Previous span</Typography>
+              <Box sx={{ display: 'flex', gap: 0.5 }}>
+                {renderKey(getModifierKey())} + {renderKey('←')}
+              </Box>
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1, width: '280px' }}>
+              <Typography variant="body2">Next span</Typography>
+              <Box sx={{ display: 'flex', gap: 0.5 }}>
+                {renderKey(getModifierKey())} + {renderKey('→')}
+              </Box>
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1, width: '280px' }}>
+              <Typography variant="body2">Back to batch</Typography>
+              <Box sx={{ display: 'flex', gap: 0.5 }}>
+                {renderKey('Esc')}
+              </Box>
+            </Box>
+          </Box>
+
+          {/* Rating Shortcuts */}
+          <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2, color: 'text.primary', textAlign: 'center' }}>
+            Rating
+          </Typography>
+          <Box sx={{ mb: 3, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1, width: '280px' }}>
+              <Typography variant="body2">Rate as Good</Typography>
+              <Box sx={{ display: 'flex', gap: 0.5 }}>
+                {renderKey(getModifierKey())} + {renderKey('↑')}
+              </Box>
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1, width: '280px' }}>
+              <Typography variant="body2">Rate as Bad</Typography>
+              <Box sx={{ display: 'flex', gap: 0.5 }}>
+                {renderKey(getModifierKey())} + {renderKey('↓')}
+              </Box>
+            </Box>
+          </Box>
+
+          {/* Auto-Save Info */}
+          <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2, color: 'text.primary', textAlign: 'center' }}>
+            Auto-Save
+          </Typography>
+          <Box sx={{ 
+            p: 2, 
+            backgroundColor: theme.palette.mode === 'dark' 
+              ? 'rgba(255, 235, 59, 0.1)' 
+              : 'rgba(255, 235, 59, 0.2)',
+            borderRadius: 2,
+            border: '1px solid',
+            borderColor: 'secondary.main'
+          }}>
+            <Typography variant="body2" sx={{ mb: 1, fontWeight: 500, textAlign: 'center' }}>
+              Your annotations are automatically saved when you:
+            </Typography>
+            <Typography variant="body2" sx={{ mb: 0.5, textAlign: 'center' }}>
+              • Navigate to previous or next span
+            </Typography>
+            <Typography variant="body2" sx={{ mb: 0.5, textAlign: 'center' }}>
+              • Return to batch (Esc key or breadcrumb)
+            </Typography>
+            <Typography variant="body2" sx={{ mb: 0.5, textAlign: 'center' }}>
+              • Navigate to project (breadcrumb)
+            </Typography>
+            <Typography variant="body2" sx={{ mt: 1.5, fontStyle: 'italic', color: 'text.secondary', textAlign: 'center' }}>
+              Note: Bad ratings require a note before auto-save will proceed.
+            </Typography>
+          </Box>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2, justifyContent: 'center' }}>
+          <Button 
+            onClick={() => setHotkeyModalOpen(false)}
+            variant="contained"
+            color="primary"
+            sx={{ 
+              minWidth: '100px',
+              fontWeight: 'bold'
+            }}
+          >
+            Got it
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Toast Notification */}
       <Snackbar

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -41,7 +41,7 @@ const Annotation = ({ onSave}: Props) => {
   const goToPreviousSpan = () => {
     if (currentSpanIndex > 0) {
       const previousSpan = annotatedRootSpans[currentSpanIndex - 1];
-      navigate(`/projects/${projectId}/batches/${batchId}/rootSpans/${previousSpan.traceId}`, {
+      navigate(`/projects/${projectId}/batches/${batchId}/annotation/${previousSpan.id}`, {
         state: { projectName, batchName, annotatedRootSpan: previousSpan }
       });
     }
@@ -50,7 +50,7 @@ const Annotation = ({ onSave}: Props) => {
   const goToNextSpan = () => {
     if (currentSpanIndex < annotatedRootSpans.length - 1) {
       const nextSpan = annotatedRootSpans[currentSpanIndex + 1];
-      navigate(`/projects/${projectId}/batches/${batchId}/rootSpans/${nextSpan.traceId}`, {
+      navigate(`/projects/${projectId}/batches/${batchId}/annotation/${nextSpan.id}`, {
         state: { projectName, batchName, annotatedRootSpan: nextSpan }
       });
     }
@@ -519,7 +519,7 @@ const Annotation = ({ onSave}: Props) => {
               </Typography>
               <TextField
                 multiline
-                rows={8}
+                rows={15}
                 fullWidth
                 variant="outlined"
                 value={note}

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -779,25 +779,32 @@ const Annotation = ({ onSave}: Props) => {
               >
                 Raw
               </Button>
-              <Button 
-                variant="outlined" 
-                size="small"
-                disabled={!currentSpan.formatted_output}
-                sx={{
-                  px: 3,
-                  minWidth: 75,
-                  borderColor: 'secondary.main',
-                  color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
-                  fontWeight: 600,
-                  '&:hover': {
-                    borderColor: 'secondary.dark',
-                    backgroundColor: 'rgba(255, 235, 59, 0.1)',
-                  }
-                }}
-                onClick={() => setDisplayFormattedInput(true)}
+              <Tooltip 
+                title={!currentSpan.formattedInput ? "Formatting in process..." : "View formatted input"}
+                arrow
               >
-                Formatted
-              </Button>
+                <span>
+                  <Button 
+                    variant="outlined" 
+                    size="small"
+                    disabled={!currentSpan.formattedInput}
+                    sx={{
+                      px: 3,
+                      minWidth: 75,
+                      borderColor: 'secondary.main',
+                      color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                      fontWeight: 600,
+                      '&:hover': {
+                        borderColor: 'secondary.dark',
+                        backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                      }
+                    }}
+                    onClick={() => setDisplayFormattedInput(true)}
+                  >
+                    Formatted
+                  </Button>
+                </span>
+              </Tooltip>
             </Box>
           </Box>
           <Box sx={{ 
@@ -813,7 +820,7 @@ const Annotation = ({ onSave}: Props) => {
               fontSize: '0.9rem',
               lineHeight: 1.5
             }}>
-              {displayFormattedInput ? <ReactMarkdown>{currentSpan.formatted_input || ''}</ReactMarkdown> : currentSpan.input}
+              {displayFormattedInput ? <ReactMarkdown>{currentSpan.formattedInput || ''}</ReactMarkdown> : currentSpan.input}
             </pre>
           </Box>
         </Paper>
@@ -859,25 +866,32 @@ const Annotation = ({ onSave}: Props) => {
               >
                 Raw
               </Button>
-              <Button 
-                variant="outlined" 
-                size="small"
-                disabled={!currentSpan.formatted_output}
-                sx={{
-                  px: 3,
-                  minWidth: 100,
-                  borderColor: 'secondary.main',
-                  color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
-                  fontWeight: 600,
-                  '&:hover': {
-                    borderColor: 'secondary.dark',
-                    backgroundColor: 'rgba(255, 235, 59, 0.1)',
-                  }
-                }}
-                onClick={() => setDisplayFormattedOutput(true)}
+              <Tooltip 
+                title={!currentSpan.formattedOutput ? "Formatting in process..." : "View formatted output"}
+                arrow
               >
-                Formatted
-              </Button>
+                <span>
+                  <Button 
+                    variant="outlined" 
+                    size="small"
+                    disabled={!currentSpan.formattedOutput}
+                    sx={{
+                      px: 3,
+                      minWidth: 100,
+                      borderColor: 'secondary.main',
+                      color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                      fontWeight: 600,
+                      '&:hover': {
+                        borderColor: 'secondary.dark',
+                        backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                      }
+                    }}
+                    onClick={() => setDisplayFormattedOutput(true)}
+                  >
+                    Formatted
+                  </Button>
+                </span>
+              </Tooltip>
             </Box>
           </Box>
           <Box sx={{ 
@@ -887,7 +901,7 @@ const Annotation = ({ onSave}: Props) => {
             backgroundColor: theme.palette.background.paper
           }}>
             {displayFormattedOutput ? (
-              <ReactMarkdown>{currentSpan.formatted_output || ''}</ReactMarkdown>
+              <ReactMarkdown>{currentSpan.formattedOutput || ''}</ReactMarkdown>
             ) : (
               <pre style={{ 
                 whiteSpace: 'pre-wrap', 

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -803,6 +803,7 @@ const Annotation = ({ onSave}: Props) => {
               <Button 
                 variant="outlined" 
                 size="small"
+                disabled={!currentSpan.formatted_output}
                 sx={{
                   px: 3,
                   minWidth: 100,

--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -64,12 +64,11 @@ const Batches = () => {
   const handleDelete = async (batchId: string) => {
     try {
       await deleteBatch(batchId);
-      // Remove the deleted batch's query from cache (don't invalidate - it would try to refetch)
-      queryClient.removeQueries({ queryKey: ['rootSpans', 'batch', batchId] });
-      // Invalidate batches list to refresh the UI
+      // Invalidate batches query to refetch data
       queryClient.invalidateQueries({ queryKey: ['batches', projectId] });
-      // Invalidate project-level rootSpans queries in case they're cached
+      // Invalidate project queries since deleted batch spans are now available for new batches
       queryClient.invalidateQueries({ queryKey: ['rootSpans', 'project', projectId] });
+      // Note: Don't invalidate the deleted batch's query - it would cause 404 errors
     } catch (error) {
       console.error("Failed to delete batch", error);
     }

--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -184,6 +184,7 @@ const Batches = ({ onDeleteBatch }: BatchProps) => {
         return (
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, py: 1 }}>
             {sortedCategories.length > 0 ? sortedCategories.map(([category, count], index) => (
+              console.log(category, count, index),
               <Chip
                 key={index}
                 label={`${category} (${count})`}

--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -114,7 +114,7 @@ const Batches = ({ onDeleteBatch }: BatchProps) => {
       ),
     },
     {
-      field: 'spanCount',
+      field: 'validRootSpanCount',
       headerName: 'Spans',
       flex: 0.5,
       minWidth: 80,
@@ -184,7 +184,6 @@ const Batches = ({ onDeleteBatch }: BatchProps) => {
         return (
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, py: 1 }}>
             {sortedCategories.length > 0 ? sortedCategories.map(([category, count], index) => (
-              console.log(category, count, index),
               <Chip
                 key={index}
                 label={`${category} (${count})`}

--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -36,8 +36,8 @@ const Batches = ({ onDeleteBatch }: BatchProps) => {
   const [open, setOpen] = useState(false);
   const [batchToDelete, setBatchToDelete] = useState<string | null>(null);
   const location = useLocation();
-  const { projectName } = location.state || {};
-  const { projectId } = useParams();
+  const { projectName, batchName } = location.state || {};
+  const { projectId, batchId } = useParams();
   const theme = useTheme();
 
   const handleClose = () => {
@@ -371,7 +371,7 @@ const Batches = ({ onDeleteBatch }: BatchProps) => {
           variant="contained"
           startIcon={<AddIcon sx={{ color: 'black !important' }} />}
           onClick={() => navigate(`/projects/${projectId}/batches/create`, { 
-            state: { projectName: projectName, projectId: projectId } 
+            state: { projectName, projectId, batchId, batchName } 
           })}
           sx={{
             backgroundColor: 'secondary.main',

--- a/src/components/CreateBatch.tsx
+++ b/src/components/CreateBatch.tsx
@@ -170,7 +170,6 @@ const CreateBatch = ({ annotatedRootSpans, onLoadRootSpans, onCreateBatch, isLoa
             <ListItemButton onClick={() => toggle(rootSpan.id)} sx={{ py: 1, px: 2 }}>
               <Checkbox 
                 checked={selectedSet.has(rootSpan.id)} 
-                onClick={(e) => e.stopPropagation()} // Prevent double-click
               />
               <ListItemText primary={`${rootSpan.traceId} — ${rootSpan.spanName}`} />
             </ListItemButton>

--- a/src/components/CreateBatch.tsx
+++ b/src/components/CreateBatch.tsx
@@ -92,13 +92,11 @@ const CreateBatch = ({ annotatedRootSpans, onLoadRootSpans, onCreateBatch, isLoa
     []
   );
 
-  const handleSubmit = useCallback(async () => {
+  const handleCreateBatch = useCallback(async () => {
     if (!name || selectedRootSpanIds.length === 0 || !projectId) return;
     
     try {
-      console.log("Creating batch", name, projectId, selectedRootSpanIds);
       const batchId = await onCreateBatch(name, projectId, selectedRootSpanIds);
-      console.log("Batch created with ID:", batchId);
       navigate(`/projects/${projectId}/batches/${batchId}`, { 
         state: { projectName: projectName, projectId: projectId, batchName: name } 
       });
@@ -184,7 +182,7 @@ const CreateBatch = ({ annotatedRootSpans, onLoadRootSpans, onCreateBatch, isLoa
         <Button
           variant="contained"
           disabled={!name || selectedRootSpanIds.length === 0}
-          onClick={handleSubmit}
+          onClick={handleCreateBatch}
         >
           Create Batch
         </Button>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -83,6 +83,11 @@ const Footer = () => {
     const newHiddenState = !isHidden;
     setIsHidden(newHiddenState);
     localStorage.setItem('llmonade-footer-hidden', JSON.stringify(newHiddenState));
+    
+    // Dispatch custom event to notify other components
+    window.dispatchEvent(new CustomEvent('footerVisibilityChanged', {
+      detail: { isHidden: newHiddenState }
+    }));
   };
 
   // Don't show footer on home/getting started page

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -102,7 +102,7 @@ const Projects = () => {
       ),
     },
     {
-      field: 'updated_at',
+      field: 'updatedAt',
       headerName: 'Last Updated At',
       flex: 1.5,
       minWidth: 150,

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -102,7 +102,7 @@ const Projects = () => {
       ),
     },
     {
-      field: 'updatedAt',
+      field: 'updated_at',
       headerName: 'Last Updated At',
       flex: 1.5,
       minWidth: 150,

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -127,7 +127,7 @@ const Projects = () => {
       ),
     },
     {
-      field: 'rootSpanCount',
+      field: 'validRootSpanCount',
       headerName: 'Root Spans',
       flex: 1,
       minWidth: 120,

--- a/src/components/RootSpanDetails.tsx
+++ b/src/components/RootSpanDetails.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import { Container, Typography, Box, Paper, Chip, Button, useTheme as muiUseTheme } from "@mui/material";
+import { Container, Typography, Box, Paper, Chip, Button, useTheme as muiUseTheme, Tooltip } from "@mui/material";
 import { useTheme } from "../contexts/ThemeContext";
 import { getPhoenixDashboardUrl } from "../services/services";
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
@@ -18,6 +18,32 @@ const RootSpanDetail = () => {
   const theme = muiUseTheme();
   const { projectId, batchId, rootSpanId } = params;
   const { projectName, batchName, annotatedRootSpan } = location.state || {};
+
+  // Helper function to render keyboard keys
+  const renderKey = (key: string) => (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-block',
+        px: 0.75,
+        py: 0.25,
+        mx: 0.5,
+        backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.08)',
+        border: '1px solid',
+        borderColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.12)',
+        borderRadius: '4px',
+        fontFamily: 'monospace',
+        fontSize: '0.75rem',
+        fontWeight: 'bold',
+        color: theme.palette.mode === 'dark' ? '#fff' : '#333',
+        boxShadow: theme.palette.mode === 'dark' 
+          ? '0 1px 0 rgba(255, 255, 255, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.05)'
+          : '0 1px 0 rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.8)'
+      }}
+    >
+      {key}
+    </Box>
+  );
 
   // Fetch all root spans for the batch to enable navigation
   const { data: allRootSpans = [], isLoading: isLoadingSpans } = useRootSpansByBatch(batchId || null);
@@ -321,52 +347,60 @@ const RootSpanDetail = () => {
             Edit Grade
           </Button>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                     <Button
-             variant="outlined"
-             onClick={goToPreviousSpan}
-             disabled={currentSpanIndex <= 0}
-             size="small"
-             sx={{ 
-               px: 3, 
-               minWidth: 165,
-               borderColor: 'secondary.main',
-               color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
-               fontWeight: 600,
-               '&:hover': {
-                 borderColor: 'secondary.dark',
-                 backgroundColor: 'rgba(255, 235, 59, 0.1)',
-               },
-               '&.Mui-disabled': {
-                 borderColor: 'text.disabled',
-                 color: 'text.disabled',
-               }
-             }}
-           >
-             Prev
-           </Button>
-           <Button
-             variant="outlined"
-             onClick={goToNextSpan}
-             disabled={currentSpanIndex >= allRootSpans.length - 1}
-             size="small"
-             sx={{ 
-               px: 3, 
-               minWidth: 165,
-               borderColor: 'secondary.main',
-               color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
-               fontWeight: 600,
-               '&:hover': {
-                 borderColor: 'secondary.dark',
-                 backgroundColor: 'rgba(255, 235, 59, 0.1)',
-               },
-               '&.Mui-disabled': {
-                 borderColor: 'text.disabled',
-                 color: 'text.disabled',
-               }
-             }}
-           >
-             Next
-           </Button>
+            <Tooltip title={<>Previous span {renderKey('←')}{renderKey('↑')}</>} arrow>
+              <span>
+                <Button
+                  variant="outlined"
+                  onClick={goToPreviousSpan}
+                  disabled={currentSpanIndex <= 0}
+                  size="small"
+                  sx={{ 
+                    px: 3, 
+                    minWidth: 165,
+                    borderColor: 'secondary.main',
+                    color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                    fontWeight: 600,
+                    '&:hover': {
+                      borderColor: 'secondary.dark',
+                      backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                    },
+                    '&.Mui-disabled': {
+                      borderColor: 'text.disabled',
+                      color: 'text.disabled',
+                    }
+                  }}
+                >
+                  Prev
+                </Button>
+              </span>
+            </Tooltip>
+            <Tooltip title={<>Next span {renderKey('→')}{renderKey('↓')}</>} arrow>
+              <span>
+                <Button
+                  variant="outlined"
+                  onClick={goToNextSpan}
+                  disabled={currentSpanIndex >= allRootSpans.length - 1}
+                  size="small"
+                  sx={{ 
+                    px: 3, 
+                    minWidth: 165,
+                    borderColor: 'secondary.main',
+                    color: theme.palette.mode === 'dark' ? '#FFFFFF' : '#000000',
+                    fontWeight: 600,
+                    '&:hover': {
+                      borderColor: 'secondary.dark',
+                      backgroundColor: 'rgba(255, 235, 59, 0.1)',
+                    },
+                    '&.Mui-disabled': {
+                      borderColor: 'text.disabled',
+                      color: 'text.disabled',
+                    }
+                  }}
+                >
+                  Next
+                </Button>
+              </span>
+            </Tooltip>
           </Box>
           </Box>
         </Box>

--- a/src/components/RootSpanDetails.tsx
+++ b/src/components/RootSpanDetails.tsx
@@ -433,7 +433,7 @@ const RootSpanDetail = () => {
                 try {
                   const phoenixUrl = await getPhoenixDashboardUrl();
                   // Open Phoenix dashboard in a new tab
-                  window.open(`${phoenixUrl}/projects/${projectId}/spans/${currentSpan.id}`, '_blank');
+                  window.open(`${phoenixUrl}/projects/${projectId}/spans/${currentSpan.traceId}`, '_blank');
                 } catch (error) {
                   console.error('Failed to get Phoenix dashboard URL:', error);
                 }

--- a/src/components/RootSpanDetails.tsx
+++ b/src/components/RootSpanDetails.tsx
@@ -24,7 +24,7 @@ const RootSpanDetail = () => {
 
   // Find current span and its index
   const currentSpanIndex = allRootSpans.findIndex(span => 
-    span.traceId === rootSpanId || span.id === annotatedRootSpan?.id
+    span.id === rootSpanId || span.id === annotatedRootSpan?.id
   );
   
   // Use the span from the API data if available, otherwise fall back to the passed one
@@ -34,7 +34,7 @@ const RootSpanDetail = () => {
   const goToPreviousSpan = () => {
     if (currentSpanIndex > 0) {
       const previousSpan = allRootSpans[currentSpanIndex - 1];
-      navigate(`/projects/${projectId}/batches/${batchId}/rootSpans/${previousSpan.traceId}`, {
+      navigate(`/projects/${projectId}/batches/${batchId}/rootSpans/${previousSpan.id}`, {
         state: { projectName, batchName, annotatedRootSpan: previousSpan }
       });
     }
@@ -43,7 +43,7 @@ const RootSpanDetail = () => {
   const goToNextSpan = () => {
     if (currentSpanIndex < allRootSpans.length - 1) {
       const nextSpan = allRootSpans[currentSpanIndex + 1];
-      navigate(`/projects/${projectId}/batches/${batchId}/rootSpans/${nextSpan.traceId}`, {
+      navigate(`/projects/${projectId}/batches/${batchId}/rootSpans/${nextSpan.id}`, {
         state: { projectName, batchName, annotatedRootSpan: nextSpan }
       });
     }
@@ -303,7 +303,7 @@ const RootSpanDetail = () => {
           <Button
             variant="contained"
             startIcon={<RateReviewIcon />}
-            onClick={() => navigate(`/projects/${projectId}/batches/${batchId}/annotation`, { 
+            onClick={() => navigate(`/projects/${projectId}/batches/${batchId}/annotation/${currentSpan.id}`, { 
               state: { projectName: projectName } 
             })}
             size="large"
@@ -433,7 +433,7 @@ const RootSpanDetail = () => {
                 try {
                   const phoenixUrl = await getPhoenixDashboardUrl();
                   // Open Phoenix dashboard in a new tab
-                  window.open(`${phoenixUrl}/projects/${projectId}/spans/${currentSpan.traceId}`, '_blank');
+                  window.open(`${phoenixUrl}/projects/${projectId}/spans/${currentSpan.id}`, '_blank');
                 } catch (error) {
                   console.error('Failed to get Phoenix dashboard URL:', error);
                 }

--- a/src/components/RootSpanDetails.tsx
+++ b/src/components/RootSpanDetails.tsx
@@ -304,7 +304,7 @@ const RootSpanDetail = () => {
             variant="contained"
             startIcon={<RateReviewIcon />}
             onClick={() => navigate(`/projects/${projectId}/batches/${batchId}/annotation/${currentSpan.id}`, { 
-              state: { projectName: projectName } 
+              state: { projectName: projectName, batchName: batchName, annotatedRootSpan: currentSpan } 
             })}
             size="large"
             sx={{ 

--- a/src/components/RootSpans.tsx
+++ b/src/components/RootSpans.tsx
@@ -872,7 +872,7 @@ const RootSpans = ({ annotatedRootSpans, onLoadRootSpans, isLoading }: RootSpans
             columns={columns}
             initialState={{
               pagination: {
-                paginationModel: { page: 0, pageSize: 10 },
+                paginationModel: { page: 0, pageSize: 25 },
               },
             }}
             pageSizeOptions={[5, 10, 25]}

--- a/src/components/RootSpans.tsx
+++ b/src/components/RootSpans.tsx
@@ -256,12 +256,12 @@ const RootSpans = ({ annotatedRootSpans, onLoadRootSpans, isLoading }: RootSpans
       await deleteRootSpan(batchId, rootSpanId);
       
       // Try to delete annotation (may not exist)
-      try {
-        await deleteAnnotation(rootSpanId);
-      } catch (annotationError) {
-        // Ignore if annotation doesn't exist
-        console.log("No annotation to delete for span:", rootSpanId);
-      }
+      // try {
+      //   await deleteAnnotation(rootSpanId);
+      // } catch (annotationError) {
+      //   // Ignore if annotation doesn't exist
+      //   console.log("No annotation to delete for span:", rootSpanId);
+      // }
       
       handleClose();
       

--- a/src/components/RootSpans.tsx
+++ b/src/components/RootSpans.tsx
@@ -242,7 +242,7 @@ const RootSpans = ({ annotatedRootSpans, onLoadRootSpans, isLoading }: RootSpans
   };
 
   const handleView = (annotatedRootSpan: AnnotatedRootSpan) => {
-    navigate(`rootSpans/${annotatedRootSpan.traceId}`, { state: { projectName, projectId, batchName, batchId: batchId, annotatedRootSpan } });
+    navigate(`annotation/${annotatedRootSpan.id}`, { state: { projectName, projectId, batchName, batchId: batchId, annotatedRootSpan } });
   };
 
   const handleCategorize = async () => {

--- a/src/components/RootSpans.tsx
+++ b/src/components/RootSpans.tsx
@@ -187,7 +187,10 @@ const RootSpans = ({ annotatedRootSpans, onLoadRootSpans, isLoading }: RootSpans
 
   const handleCategorizeModalClose = () => {
     setCategorizeModalOpen(false);
-    setCategorizeResults(null);
+    // Delay clearing results until after dialog close animation completes
+    setTimeout(() => {
+      setCategorizeResults(null);
+    }, 300); // MUI dialog close animation is typically ~225ms
   };
 
   const handleSnackbarClose = () => {

--- a/src/components/RootSpans.tsx
+++ b/src/components/RootSpans.tsx
@@ -658,7 +658,7 @@ const RootSpans = ({ annotatedRootSpans, onLoadRootSpans, isLoading }: RootSpans
           <Button
             variant="contained"
             startIcon={<RateReviewIcon />}
-            onClick={() => navigate(`/projects/${projectId}/batches/${batchId}/annotation`, { 
+            onClick={() => navigate(`/projects/${projectId}/batches/${batchId}/annotation/${annotatedRootSpans[0].id}`, { 
               state: { projectName: projectName || annotatedRootSpans[0]?.projectName, projectId, batchName } 
             })}
             size="large"

--- a/src/components/RootSpans.tsx
+++ b/src/components/RootSpans.tsx
@@ -137,7 +137,7 @@ interface RootSpansProps {
 }
 
 const RootSpans = ({ annotatedRootSpans, onLoadRootSpans, isLoading }: RootSpansProps) => {
-  const [pageSize, setPageSize] = useState(10);
+  const [pageSize, setPageSize] = useState(25);
   const [searchTerm, setSearchTerm] = useState('');
   const [open, setOpen] = useState(false);
   const [rootSpanToDelete, setRootSpanToDelete] = useState<string | null>(null);

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { AnnotatedRootSpan, Annotation, Rating, Project } from '../types/types';
+import type { AnnotatedRootSpan, Annotation, Rating, Project, Batch } from '../types/types';
 
 export const fetchRootSpan = async (id: string): Promise<AnnotatedRootSpan> => {
   const response = await axios.get<AnnotatedRootSpan>(`/api/rootSpans/${id}`);
@@ -38,15 +38,7 @@ export const categorizeAnnotations = async (batchId: string): Promise<
   return response.data;
 };
 
-export const fetchBatches = async (projectId: string): Promise<{ 
-  id: string;
-  projectId: string;
-  name: string;
-  createdAt: string;
-  spanCount: number;
-  percentAnnotated: number;
-  percentGood: number;
-  categories: Record<string, number>; }[]> => {
+export const fetchBatches = async (projectId: string): Promise<Batch[]> => {
   const response = await axios.get(`/api/projects/${projectId}`);
   return response.data;
 }
@@ -75,8 +67,6 @@ export const deleteRootSpan = async (batchId: string, spanId: string) => {
   const response = await axios.delete(`/api/batches/${batchId}/spans/${spanId}`);
   return response.data;
 }
-
-
 
 export const getPhoenixDashboardUrl = async (): Promise<string> => {
   const response = await axios.get('/api/phoenixDashboardUrl');

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -91,7 +91,7 @@ export const fetchProjects = async (): Promise<Project[]> => {
 export const fetchRootSpansByBatch = async (batchId: string): Promise<AnnotatedRootSpan[]> => {
   const response = await axios.get(`/api/batches/${batchId}`, {
     params: {
-      numPerPage: 200
+      numPerPage: 100
     }
   });
   return response.data.rootSpans;
@@ -101,7 +101,7 @@ export const fetchRootSpansByProject = async (projectId: string): Promise<Annota
   const response = await axios.get('/api/rootSpans', {
     params: { 
       projectId,
-      numPerPage: 2000 // Large number to get all spans
+      numPerPage: 100 // Large number to get all spans
     }
   });
   return response.data.rootSpans;
@@ -112,7 +112,7 @@ export const fetchBatchlessSpansByProject = async (projectId: string): Promise<A
   const response = await axios.get('/api/batches/unbatched', {
     params: { 
       projectId,
-      numPerPage: 1000 // Large number to get all spans
+      numPerPage: 100 // Large number to get all spans
     }
   });
   return response.data.batchlessRootSpans;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -96,14 +96,3 @@ export const fetchRootSpansByProject = async (projectId: string): Promise<Annota
   });
   return response.data.rootSpans;
 }
-
-// Fetch unbatched spans for a project (useful for CreateBatch)
-export const fetchBatchlessSpansByProject = async (projectId: string): Promise<AnnotatedRootSpan[]> => {
-  const response = await axios.get('/api/batches/unbatched', {
-    params: { 
-      projectId,
-      numPerPage: 100
-    }
-  });
-  return response.data.batchlessRootSpans;
-}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -53,6 +53,6 @@ export interface Project {
   name: string;
   createdAt: string;
   updatedAt: string;
-  rootSpanCount: number;
+  validRootSpanCount: number;
   numBatches: number;
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -31,8 +31,8 @@ export interface AnnotatedRootSpan {
   endTime: string | null;
   input: string;
   output: string;
-  formatted_input?: string;
-  formatted_output?: string;
+  formattedInput?: string;
+  formattedOutput?: string;
   projectId?: string;
   projectName?: string;
   spanName: string | null;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -31,6 +31,8 @@ export interface AnnotatedRootSpan {
   endTime: string | null;
   input: string;
   output: string;
+  formatted_input?: string;
+  formatted_output?: string;
   projectId?: string;
   projectName?: string;
   spanName: string | null;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -42,7 +42,7 @@ export interface Batch {
   projectId: string;
   name: string;
   createdAt: string;
-  spanCount: number;
+  validRootSpanCount: number;
   percentAnnotated: number;
   percentGood: number;
   categories: Record<string, number>;


### PR DESCRIPTION
Updated annotation page in several ways to follow Hammel suggestions.
- updated routing so we can use back/forward navigation with annotations for specific root spans
- update format to use css grid to see input/output/metadata/annotation
- progress bar to show how many root spans have been graded
- added hotkeys to quickly navigate between spans and to add freeform notes
- auto-focus to freeform notes section to enable easy typing
- auto-saves any changes on navigating
- dialog box to confirm start categorize when you reach end of the batch